### PR TITLE
NXBT-3129 auth against maven-eu.nuxeo.org

### DIFF
--- a/parms/central/repository-parms.json
+++ b/parms/central/repository-parms.json
@@ -453,6 +453,10 @@
     "artifactory.arondor.cloud": {
       "auth_type": "username",
       "user": "nuxeo"
+    },
+    "maven-eu.nuxeo.org": {
+      "auth_type": "username",
+      "user": "packages"
     }
   },
   "blobstores": {


### PR DESCRIPTION
Initially adding auth to maven-vendor-archives.
This auth was actually not needed, the repo being public.
Worth to keep the reference to maven-eu.nuxeo.org login though